### PR TITLE
Update version in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Canvas.MixProject do
   def project do
     [
       app: :canvas,
-      version: "0.1",
+      version: "0.1.0",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
Hey there ✌️
Fixed the version number to comply with semver, so that Mix to stops throwing an error when starting up..

`** (Mix) Expected :version to be a valid Version, got: "0.1" (see the Version module for more information)`

